### PR TITLE
Change tostring to tobytes

### DIFF
--- a/opuslib/api/__init__.py
+++ b/opuslib/api/__init__.py
@@ -12,6 +12,8 @@ import ctypes  # NOQA
 
 from ctypes.util import find_library  # NOQA
 
+import array
+import sys
 
 lib_location = find_library('opus')
 
@@ -24,3 +26,10 @@ libopus = ctypes.CDLL(lib_location)
 c_int_pointer = ctypes.POINTER(ctypes.c_int)
 c_int16_pointer = ctypes.POINTER(ctypes.c_int16)
 c_float_pointer = ctypes.POINTER(ctypes.c_float)
+
+if sys.version_info < (3, 2):
+    class Array(array.array):
+        def tobytes(self):
+            return self.tostring()
+else:
+    Array = array.array

--- a/opuslib/api/decoder.py
+++ b/opuslib/api/decoder.py
@@ -6,7 +6,6 @@ __copyright__ = 'Copyright (c) 2012, SvartalF'
 __license__ = 'BSD 3-Clause License'
 
 
-import array
 import ctypes
 
 import opuslib.api
@@ -178,7 +177,7 @@ def decode(decoder, data, length, frame_size, decode_fec, channels=2):
     if result < 0:
         raise opuslib.exceptions.OpusError(result)
 
-    return array.array('h', pcm[:result * channels]).tostring()
+    return opuslib.api.Array('h', pcm[:result * channels]).tobytes()
 
 
 _decode_float = opuslib.api.libopus.opus_decode_float
@@ -206,7 +205,7 @@ def decode_float(decoder, data, length, frame_size, decode_fec, channels=2):
     if result < 0:
         raise opuslib.exceptions.OpusError(result)
 
-    return array.array('f', pcm[:result * channels]).tostring()
+    return opuslib.api.Array('f', pcm[:result * channels]).tobytes()
 
 
 _ctl = opuslib.api.libopus.opus_decoder_ctl

--- a/opuslib/api/encoder.py
+++ b/opuslib/api/encoder.py
@@ -7,7 +7,6 @@ __license__ = 'BSD 3-Clause License'
 
 
 import ctypes
-import array
 
 import opuslib.api
 import opuslib.api.constants
@@ -89,7 +88,7 @@ def encode(encoder, pcm, frame_size, max_data_bytes):
         raise opuslib.exceptions.OpusError(
             "Encoder returned: %s" % result)
 
-    return array.array('b', data[:result]).tostring()
+    return opuslib.api.Array('b', data[:result]).tobytes()
 
 
 _encode_float = opuslib.api.libopus.opus_encode_float
@@ -110,7 +109,7 @@ def encode_float(encoder, pcm, frame_size, max_data_bytes):
         raise opuslib.exceptions.OpusError(
             "Encoder returned: %s" % result)
 
-    return array.array('b', data[:result]).tostring()
+    return opuslib.api.Array('b', data[:result]).tobytes()
 
 
 destroy = opuslib.api.libopus.opus_encoder_destroy


### PR DESCRIPTION
Python 3.2 renamed tostring to tobytes, using tostring on 3.7 raises a DeprecationWarning. This patch switches to the new function name while maintaining Python 2 compatibility.

(On a related note I've been using opuslib on Python 3 for quite some time now without any changes. https://github.com/azlux/pymumble is on Python 3 and works just fine with opuslib.)